### PR TITLE
Repo Settings and Build Script

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,8 @@
+#############################################
+#  PML User Manual:                         #
+#  https://github.com/pml-lang/user-manual  #
+#############################################
+
 root = true
 
 ## Repository Configurations
@@ -9,6 +14,40 @@ indent_size = unset
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+
+## Markdown GFM
+###############
+[*.md]
+indent_style = space
+indent_size = unset
+end_of_line = unset
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+
+## Shell Scripts
+################
+[*.sh]
+end_of_line = lf
+indent_style = tab
+indent_size = unset
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+
+## Batch Scripts
+################
+[*.bat]
+indent_style = tab
+indent_size = unset
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
 
 ## PML Markup
 #############

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,30 @@
+#############################################
+#  PML User Manual:                         #
+#  https://github.com/pml-lang/user-manual  #
+#############################################
+
+* text=auto
+
+## Repository Configuration
+###########################
+.editorconfig    text eol=lf
+.gitlab-ci.yml   text eol=lf
+.travis.yml      text eol=lf
+.gitattributes   text eol=lf
+.gitconfig       text eol=lf
+.gitignore       text eol=lf
+.gitmodules      text eol=lf
+
+
+## Documentation Files
+######################
+*.pml     text
+*.md      text
+*.txt     text
+LICENSE   text
+
+
+## Scripts
+##########
+*.sh    text eol=lf
+*.bat   text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+#############################################
+#  PML User Manual:                         #
+#  https://github.com/pml-lang/user-manual  #
+#############################################
+
 /bin
 /output
 /temp
@@ -8,3 +13,97 @@
 
 # Directories and files starting with NOGIT_
 **/NOGIT_*
+
+
+## Misc Work Files
+##################
+
+# Temporary/backup or removed files and folders:
+___*
+___*.*
+
+# Links and URLs
+*.lnk
+*.url
+
+
+## Apps Local Settings & Temp Files
+###################################
+
+# Chrome's debug logs for local HTML pages:
+debug.log
+
+
+############################
+## COMMON IGNORE PATTERNS ##
+############################
+# Based on ".gitignore" created by:
+# https://www.gitignore.io/api/windows,linux,macos
+
+## Linux
+########
+
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+## macOS
+########
+
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+## Windows
+##########
+
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# End of https://www.gitignore.io/api/windows,linux,macos,purebasic

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+SemVer="[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+"
+if ! currPMLver="$(expr "$(pmlc --version 2> /dev/null)" : \
+				".*version\:\? \($SemVer\)")" ; then
+	echo "ERROR: You need to install the PML Converter:"
+	echo "       https://www.pml-lang.dev/downloads/install.html"
+	exit 1
+fi
+
+reqPMLver="$(< VERSION)"
+if ! [[ $currPMLver == $reqPMLver ]] ;then
+	echo -e "WARNING: This project requires PML $reqPMLver" \
+			"(you have $currPMLver).\n        " \
+			"Make sure you're local repository is up to date,\n        " \
+			"and that you're using the latest PML version."
+fi
+
+pmlc convert --input_file input/text/index.pml
+
+echo -e "\n/// Done ///"
+exit


### PR DESCRIPTION
Update EditorConfig and Git ignore rules; add `.gitattributes` settings.

Add `build.sh` script to build the User Manual after checking that PML
is installed on the user machine, and the it matches the version found
in the `VERSION` file (issuing a warning if it doesn't).